### PR TITLE
Version 0.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       - name: gcc make
         run: make TYPE=test
       - name: gcc tests
-        run: make test
+        run: make TYPE=test test
 
       # run
       - name: test

--- a/makefile
+++ b/makefile
@@ -82,8 +82,18 @@ TESTBUILD	:= $(TESTDIR)/objs
 TESTTARGET	:= $(TESTDIR)/bin
 TESTCOV		:= coverage/test
 
-TESTFLAGS	:= -g $(DEFINES) -Wall -Wno-unknown-pragmas -Wno-format -fprofile-arcs -ftest-coverage
-TESTLIBS	:= $(PTHREAD) -lgcov --coverage -L ./bin -l ctest
+TESTFLAGS	:= -g $(DEFINES) -Wall -Wno-unknown-pragmas -Wno-format
+
+ifeq ($(TYPE), test)
+	TESTFLAGS += -fprofile-arcs -ftest-coverage
+endif
+
+TESTLIBS	:= $(PTHREAD) -L ./bin -l ctest
+
+ifeq ($(TYPE), test)
+	TESTLIBS += -lgcov --coverage
+endif
+
 TESTINC		:= -I ./$(TESTDIR)
 
 TESTS		:= $(shell find $(TESTDIR) -type f -name *.$(SRCEXT))

--- a/src/ctest/htab.c
+++ b/src/ctest/htab.c
@@ -377,8 +377,11 @@ int htab_insert (
 				ht,
 				key, key_size, node->key, node->key_size
 			)) {
-				node->next = htab_node_create (key, key_size, val, val_size,
-					ht->key_create);
+				node->next = htab_node_create (
+					key, key_size, val, val_size,
+					ht->key_create
+				);
+				
 				if (node->next) {
 					node = node->next;
 
@@ -453,7 +456,8 @@ void *htab_get (
 
 }
 
-// removes the data associated with the key from the htab
+// removes and returns the data associated with the key from the htab
+// the data should be deleted by the user
 // returns NULL if no data was found with the provided key
 void *htab_remove (
 	Htab *ht, const void *key, size_t key_size
@@ -478,6 +482,7 @@ void *htab_remove (
 
 				retval = node->val;
 
+				node->val = NULL;
 				htab_node_delete (node, ht->key_delete, ht->delete_data);
 
 				bucket->count--;

--- a/test.sh
+++ b/test.sh
@@ -7,7 +7,7 @@ make clean
 printf "gcc make\n\n"
 make TYPE=test -j8
 printf "\n\ngcc test\n\n"
-make test -j8
+make TYPE=test test -j8
 
 # run
 printf "\n\ntest\n\n"

--- a/test/test.c
+++ b/test/test.c
@@ -6,7 +6,15 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-parameter"
 
+extern void collections_tests_htab (void);
+
 int main (int argc, char const **argv) {
+
+	(void) printf ("Testing COLLECTIONS...\n");
+
+	collections_tests_htab ();
+
+	(void) printf ("\nDone with COLLECTIONS tests!\n\n");
 
 	(void) printf ("Testing UTILS...\n");
 

--- a/test/test.h
+++ b/test/test.h
@@ -38,6 +38,46 @@
 #define test_check_int_gt(X, Y) test_check (X > Y, NULL)
 
 #define																\
+	test_check_ptr(ptr)												\
+	({																\
+		if (!ptr) {													\
+			where;													\
+			(void) fprintf (stderr, "Pointer is NULL!");			\
+			exit (1);												\
+		}															\
+	})
+
+#define																\
+	test_check_null_ptr(ptr)												\
+	({																\
+		if (ptr) {													\
+			where;													\
+			(void) fprintf (stderr, "Pointer is NOT NULL!");		\
+			exit (1);												\
+		}															\
+	})
+
+#define																\
+	test_check_true(value)											\
+	({																\
+		if (!value) {												\
+			where;													\
+			(void) fprintf (stderr, "Value is NOT true!");			\
+			exit (1);												\
+		}															\
+	})
+
+#define																\
+	test_check_false(value)											\
+	({																\
+		if (value) {												\
+			where;													\
+			(void) fprintf (stderr, "Value is NOT false!");			\
+			exit (1);												\
+		}															\
+	})
+
+#define																\
 	test_check_int_eq(value, expected, msg)							\
 	({																\
 		if (value != expected) {									\

--- a/test/test_htab.c
+++ b/test/test_htab.c
@@ -319,6 +319,137 @@ static void test_htab_int_remove_multiple (void) {
 
 }
 
+static void test_htab_int_get_single (void) {
+
+	Htab *map = test_htab_create ();
+
+	unsigned int idx = 0;
+	Data *data = data_new (idx, 1000);
+
+	const void *key = &idx;
+	int resutl = htab_insert (
+		map,
+		key, sizeof (unsigned int),
+		data, sizeof (Data)
+	);
+
+	test_check_int_eq (resutl, 0, NULL);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	void *value = NULL;
+
+	// get bad value
+	unsigned int bad_key = 1;
+	key = &bad_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_null_ptr (value);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// get good value
+	unsigned int good_key = 0;
+	key = &good_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_ptr (value);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// get good value again
+	key = &good_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_ptr (value);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// get bad again
+	key = &bad_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_null_ptr (value);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// htab_print (map);
+
+	htab_destroy (map);
+
+}
+
+static void test_htab_int_get_multple (void) {
+
+	Htab *map = test_htab_create ();
+
+	// insert multiple values
+	unsigned int val = 1000;
+	Data *data = NULL;	
+	for (unsigned int i = 0; i < 10; i++) {
+		const void *key = &i;
+
+		data = data_new (i, val);
+		val++;
+
+		int result = htab_insert (
+			map,
+			key, sizeof (unsigned int),
+			data, sizeof (Data)
+		);
+
+		test_check_int_eq (result, 0, NULL);
+	}
+
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	void *value = NULL;
+
+	// get bad value
+	unsigned int bad_key = 11;
+	void *key = &bad_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_null_ptr (value);
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// get good value
+	unsigned int good_key = 0;
+	key = &good_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_ptr (value);
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// get another good value
+	unsigned int another_good_key = 6;
+	key = &another_good_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_ptr (value);
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// get another bad value
+	unsigned int another_bad_key = 127;
+	key = &another_bad_key;
+	value = htab_get (map, key, sizeof (unsigned int));
+	test_check_null_ptr (value);
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// htab_print (map);
+
+	htab_destroy (map);
+
+}
+
 void collections_tests_htab (void) {
 
 	(void) printf ("Testing COLLECTIONS htab...\n");
@@ -330,6 +461,10 @@ void collections_tests_htab (void) {
 	test_htab_int_remove_single ();
 
 	test_htab_int_remove_multiple ();
+
+	test_htab_int_get_single ();
+
+	test_htab_int_get_multple ();
 
 	(void) printf ("Done!\n");
 

--- a/test/test_htab.c
+++ b/test/test_htab.c
@@ -1,0 +1,336 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <ctest/htab.h>
+
+#include "test.h"
+
+typedef struct Data {
+
+	unsigned int idx;
+	unsigned int value;
+
+} Data;
+
+static inline Data *data_new (
+	const unsigned int idx, const unsigned int value
+) {
+
+	Data *data = (Data *) malloc (sizeof (Data));
+	if (data) {
+		data->idx = idx;
+		data->value = value;
+	}
+
+	return data;
+
+}
+
+static inline void data_delete (void *data_ptr) {
+
+	if (data_ptr) free (data_ptr);
+
+}
+
+static inline void data_print (Data *data) {
+
+	(void) printf ("idx: %u - value: %u\n", data->idx, data->value);
+
+}
+
+static Htab *test_htab_create (void) {
+
+	Htab *map = htab_create (
+		HTAB_DEFAULT_INIT_SIZE,
+		NULL,
+		data_delete
+	);
+
+	test_check_ptr (map);
+	test_check_int_eq ((int) map->size, HTAB_DEFAULT_INIT_SIZE, NULL);
+	test_check_int_eq ((int) map->count, 0, NULL);
+	test_check_true (htab_is_empty (map));
+	test_check_false (htab_is_not_empty (map));
+
+	return map;
+
+}
+
+// create a new map and insert a single value
+static void test_htab_int_insert_single (void) {
+
+	Htab *map = test_htab_create ();
+
+	unsigned int idx = 0;
+	unsigned int value = 1;
+	Data *data = data_new (idx, value);
+
+	const void *key = &idx;
+	int resutl = htab_insert (
+		map,
+		key, sizeof (unsigned int),
+		data, sizeof (Data)
+	);
+
+	test_check_int_eq (resutl, 0, NULL);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// htab_print (map);
+
+	htab_destroy (map);
+
+}
+
+// create a new map and insert multiple values
+static void test_htab_int_insert_multiple (void) {
+
+	Htab *map = test_htab_create ();
+
+	unsigned int value = 1000;
+	Data *data = NULL;	
+	for (unsigned int i = 0; i < 10; i++) {
+		const void *key = &i;
+
+		data = data_new (i, value);
+		value++;
+
+		int result = htab_insert (
+			map,
+			key, sizeof (unsigned int),
+			data, sizeof (Data)
+		);
+
+		test_check_int_eq (result, 0, NULL);
+	}
+
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// htab_print (map);
+
+	htab_destroy (map);
+
+}
+
+// create a map
+// insert and remove a single value
+static void test_htab_int_remove_single (void) {
+
+	Htab *map = test_htab_create ();
+
+	unsigned int idx = 1;
+	unsigned int value = 10;
+	Data *data = data_new (idx, value);
+
+	void *key = &idx;
+	int resutl = htab_insert (
+		map,
+		key, sizeof (unsigned int),
+		data, sizeof (Data)
+	);
+
+	// after insertion
+	test_check_int_eq (resutl, 0, NULL);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	void *removed = NULL;
+
+	// remove NULL value
+	removed = htab_remove (map, NULL, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// remove bad value
+	unsigned int bad_key = 2;
+	key = &bad_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// remove good value
+	unsigned int good_key = 1;
+	key = &good_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_ptr (removed);
+	test_check_int_eq ((int) map->count, 0, NULL);
+	test_check_true (htab_is_empty (map));
+	test_check_false (htab_is_not_empty (map));
+	data_delete (removed);
+
+	// remove good value again
+	key = &good_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 0, NULL);
+	test_check_true (htab_is_empty (map));
+	test_check_false (htab_is_not_empty (map));
+
+	// remove unmatched value
+	key = &bad_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 0, NULL);
+	test_check_true (htab_is_empty (map));
+	test_check_false (htab_is_not_empty (map));
+
+	// remove unmatched value again
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 0, NULL);
+	test_check_true (htab_is_empty (map));
+	test_check_false (htab_is_not_empty (map));
+
+	htab_destroy (map);
+
+}
+
+// create a map
+// insert and remove multiple values
+static void test_htab_int_remove_multiple (void) {
+
+	Htab *map = test_htab_create ();
+
+	unsigned int idx = 0;
+
+	// insert 10 elements
+	unsigned int value = 1000;
+	Data *data = NULL;
+	for (idx = 0; idx < 10; idx++) {
+		const void *key = &idx;
+
+		data = data_new (idx, value);
+
+		int result = htab_insert (
+			map,
+			key, sizeof (unsigned int),
+			data, sizeof (Data)
+		);
+
+		test_check_int_eq (result, 0, NULL);
+
+		value++;
+	}
+
+	// check for insertions
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	void *key = 0;
+	void *removed = NULL;
+
+	// remove NULL value
+	removed = htab_remove (map, NULL, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// remove bad value
+	unsigned int bad_key = 20;
+	key = &bad_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 10, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	// remove good value
+	unsigned int good_key = 2;
+	key = &good_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_ptr (removed);
+	test_check_int_eq ((int) map->count, 9, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+	data_delete (removed);
+
+	// remove another good value
+	unsigned int another_good_key = 7;
+	key = &another_good_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_ptr (removed);
+	test_check_int_eq ((int) map->count, 8, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+	data_delete (removed);
+
+	// remove the remaining of the values
+	for (idx = 0; idx < 10; idx++) {
+		const void *key = &idx;
+
+		// the values that we removed before
+		if ((idx == 2) || (idx == 7)) {
+			removed = htab_remove (map, key, sizeof (unsigned int));
+			test_check_null_ptr (removed);
+			test_check_false (htab_is_empty (map));
+			test_check_true (htab_is_not_empty (map));
+		}
+
+		else {
+			removed = htab_remove (map, key, sizeof (unsigned int));
+			test_check_ptr (removed);
+			data_delete (removed);
+		}
+	}
+
+	// try to remove a previous good value 
+	unsigned int prev_key = 4;
+	key = &prev_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 0, NULL);
+	test_check_true (htab_is_empty (map));
+	test_check_false (htab_is_not_empty (map));
+
+	// try to remove a bad value
+	unsigned int another_bad_key = 100;
+	key = &another_bad_key;
+	removed = htab_remove (map, key, sizeof (unsigned int));
+	test_check_null_ptr (removed);
+	test_check_int_eq ((int) map->count, 0, NULL);
+	test_check_true (htab_is_empty (map));
+	test_check_false (htab_is_not_empty (map));
+
+	// insert a new value
+	unsigned int final_value = 18;
+	key = &final_value;
+	int resutl = htab_insert (
+		map,
+		key, sizeof (unsigned int),
+		data, sizeof (Data)
+	);
+	test_check_int_eq (resutl, 0, NULL);
+	test_check_int_eq ((int) map->count, 1, NULL);
+	test_check_false (htab_is_empty (map));
+	test_check_true (htab_is_not_empty (map));
+
+	htab_destroy (map);
+
+}
+
+void collections_tests_htab (void) {
+
+	(void) printf ("Testing COLLECTIONS htab...\n");
+
+	test_htab_int_insert_single ();
+
+	test_htab_int_insert_multiple ();
+
+	test_htab_int_remove_single ();
+
+	test_htab_int_remove_multiple ();
+
+	(void) printf ("Done!\n");
+
+}


### PR DESCRIPTION
## General
- Fixed htab_remove () return value
- Setting TYPE=test when compiling tests in script & build workflow

## Test
- Added more test check macros
- Only adding coverage flags to tests when TYPE=test
- Added base htab test methods